### PR TITLE
feat(panels): dont require title for panel embed

### DIFF
--- a/src/routes/settings/[guild]/panels/+page.svelte
+++ b/src/routes/settings/[guild]/panels/+page.svelte
@@ -174,11 +174,9 @@
 				<div>
 					<label>
 						<span class="font-medium">Title</span>
-						<Required />
 						<i
 							class="fa-solid fa-circle-question cursor-help text-gray-500 dark:text-slate-400"
 							title="The embed title"
-							required
 						></i>
 						<input type="text" class="input form-input" required bind:value={panel.title} />
 					</label>


### PR DESCRIPTION
I removed the requirement for an title for the panel embed.
This wont break, because the default value is already set to an empty string and the implementation [here](https://github.com/discord-tickets/bot/blob/088b980192dc8b22888c62e4ce334a8b006d49eb/src/routes/api/admin/guilds/%5Bguild%5D/panels.js#L66) won´t break with an empty string.

Why?
In my usecase i created the whole "ui" of the embed inside the body with markdown styling and therefore don´t want to set an title for the embed.